### PR TITLE
Fix cover creation

### DIFF
--- a/static/client/make-cover.js
+++ b/static/client/make-cover.js
@@ -287,7 +287,6 @@ async function makeCover({
             line-height: 1;
             text-transform: uppercase;
             text-align: center;
-            /*font-size: 7vh;*/
         }
         .cover-text {
             grid-row: 1 / 1;

--- a/static/client/make-cover.js
+++ b/static/client/make-cover.js
@@ -202,12 +202,13 @@ async function makeCover({
 
     if (elements.logo) {
         elements.logo.id = 'image';
+        elements.logo.className = 'cover-image';
     }
 
     document.body.innerHTML = `<div class="cover">
         <div class="cover-text">
             <div class="text-item">
-                <h1 id="title" class="top-text fit"><span>${title}</span></h1>
+                <h1 id="page-title" class="top-text fit"><span>${title}</span></h1>
             </div>
             <div class="text-item">
                 <h2 id="author" class="bottom-text fit"><span>${author}</span></h2>
@@ -218,7 +219,7 @@ async function makeCover({
     <div id="extra-div-2"><span></span></div>`;
     
     const imgContainer = document.querySelector('#image-container');
-    const titleEl = document.querySelector('#title');
+    const titleEl = document.querySelector('#page-title');
     const authorEl = document.querySelector('#author');
     if (elements.logo) imgContainer.appendChild(elements.logo);
     
@@ -226,13 +227,14 @@ async function makeCover({
 
     var s = document.createElement('style');
     s.innerText = `
-    :root {
+        :root {
             --header-background-image-size: 100% 100%;
             --header-height-on-mobile: 100%;
             --header-height-on-desktop: 100%;
         }
         body {
             margin: 0;
+            padding: 20px;
             box-sizing: border-box;
             width: 100vw;
             height: 100vh;
@@ -242,6 +244,7 @@ async function makeCover({
             background-position: center;
             background-size: cover;`
                 : ''}
+            background-size: auto;
         }
         .cover-content {
             text-align: center;
@@ -261,17 +264,30 @@ async function makeCover({
             align-content: space-evenly;
         }
         .cover-image {
-            width: 90%;
-            height: 50%;
+            width: 90vw;
+            height: 50vh;
             object-fit: contain;
             margin: 0 auto;
 
         }
-        #title, #author, .cover .cover-title, .cover .cover-subtitle {
+        @media (max-aspect-ratio: 4/5) {
+            .cover-image {
+                height: 66vh;
+            }
+        }
+        @media (max-aspect-ratio: 6/5) {
+            .text-item {
+                min-height: 20%;
+                align-items: center;
+            }
+        }
+        #page-title, #author, .cover .cover-title, .cover .cover-subtitle {
             margin: 0 !important;
             padding: 0 !important;
             line-height: 1;
             text-transform: uppercase;
+            text-align: center;
+            /*font-size: 7vh;*/
         }
         .cover-text {
             grid-row: 1 / 1;
@@ -282,6 +298,7 @@ async function makeCover({
             left: 0; */
             width: 100%;
             height: 100%;
+            max-width: calc(100vw - 5%);
             padding: 20px;
             box-sizing: border-box;
             display: flex;
@@ -289,6 +306,22 @@ async function makeCover({
             justify-content: space-between;
             padding: 5% 5%;
             color: rgb(var(--swatch-text-light));
+        }
+        h1 {
+            --inverted-title-color: var(--swatch-background);
+            filter: 
+                drop-shadow(.01em .01em rgb(var(--inverted-title-color)))
+                drop-shadow(.01em -.01em rgb(var(--inverted-title-color)))
+                drop-shadow(-.01em .01em rgb(var(--inverted-title-color)))
+                drop-shadow(.01em .01em rgb(var(--inverted-title-color)));
+        }
+        h2 {
+            --inverted-author-color: var(--swatch-text-dark);
+            filter: 
+                drop-shadow(.01em .01em rgb(var(--inverted-author-color)))
+                drop-shadow(.01em -.01em rgb(var(--inverted-author-color)))
+                drop-shadow(-.01em .01em rgb(var(--inverted-author-color)))
+                drop-shadow(.01em .01em rgb(var(--inverted-author-color)));
         }
         .text-item {
             width: 100%;
@@ -301,7 +334,8 @@ async function makeCover({
             grid-template-rows: 1fr;
         }
         .cover-image {
-            color: rgb(var(--bright-accent, 255 255 255));
+            color: rgb(var(--swatch-text-general));
+            opacity: .75;
         }
         .cover-image-container {
             grid-row: 1 / 1;
@@ -312,25 +346,13 @@ async function makeCover({
             align-items: center;
             height: 100vh;
         }
-        @media (max-aspect-ratio: 4/5) {
-            .cover-image {
-                height: 66%;
-            }
-        }
-        @media (max-aspect-ratio: 6/5) {
-            .text-item {
-                min-height: 20%;
-                align-items: center;
-            }
-        }
 `;
     document.head.appendChild(s);
     await new Promise(done => setTimeout(done, 100));
     
-    fitty('.top-text.fit', { minSize: 24, maxSize: 120, observeMutations: false });
+    fitty('.top-text.fit', { minSize: document.documentElement.clientHeight * 0.06,  observeMutations: false });
     await new Promise(done => setTimeout(done, 100));
-    var titleSize = getComputedStyle(titleEl).fontSize;
-    fitty('.bottom-text.fit', { minSize: 24, maxSize: titleSize.endsWith('px') ? parseInt(titleSize) : 96, observeMutations: false });
+    fitty('.bottom-text.fit', { minSize: document.documentElement.clientHeight * 0.06,  observeMutations: false });
 
     await new Promise(done => setTimeout(done, 100));
 

--- a/static/cover.html
+++ b/static/cover.html
@@ -70,7 +70,6 @@
             line-height: 1;
             text-transform: uppercase;
             text-align: center;
-            /*font-size: 7vh;*/
         }
         .cover-text {
             grid-row: 1 / 1;
@@ -99,26 +98,17 @@
             margin: 0;
             padding: 0;
             
-            /* -webkit-text-stroke-width: 3pt;
-            -webkit-text-stroke-color: rgba(0, 0, 0, 1); */
             --inverted-title-color: var(--swatch-background);
             filter: 
                 drop-shadow(.01em .01em rgb(var(--inverted-title-color)))
                 drop-shadow(.01em -.01em rgb(var(--inverted-title-color)))
                 drop-shadow(-.01em .01em rgb(var(--inverted-title-color)))
                 drop-shadow(.01em .01em rgb(var(--inverted-title-color)));
-            /*text-shadow: 
-                -.2vh -.2vh .1vh rgb(var(--inverted-title-color)), 
-                .2vh -.2vh .1vh rgb(var(--inverted-title-color)),
-                -.2vh .2vh .1vh rgb(var(--inverted-title-color)), 
-                .2vh .2vh .1vh rgb(var(--inverted-title-color));*/
         }
         h2 {
             margin: 0;
             padding: 0;
             
-            /* -webkit-text-stroke-width: 3pt;
-            -webkit-text-stroke-color: rgba(0, 0, 0, 1); */
             --inverted-author-color: var(--swatch-text-dark);
             filter: 
                 drop-shadow(.01em .01em rgb(var(--inverted-author-color)))

--- a/static/cover.html
+++ b/static/cover.html
@@ -12,6 +12,7 @@
         @import url(https://cdn.scpwiki.com/theme/en/sigma/css/sigma.min.css);
         @import url("https://cdn.scpwiki.com/theme/en/black-highlighter/css/min/normalize.min.css");
         @import url("https://cdn.scpwiki.com/theme/en/black-highlighter/css/min/black-highlighter.min.css");
+        @import url("https://scp-wiki.wdfiles.com/local--code/theme:extra-black-highlighter-theme");
 
 
         :root {
@@ -26,6 +27,7 @@
             width: 100vw;
             height: 100vh;
             overflow: hidden;
+            background-size: auto;
         }
         .cover-content {
             text-align: center;
@@ -45,15 +47,15 @@
             align-content: space-evenly;
         }
         .cover-image {
-            width: 90%;
-            height: 50%;
+            width: 90vw;
+            height: 50vh;
             object-fit: contain;
             margin: 0 auto;
 
         }
         @media (max-aspect-ratio: 4/5) {
             .cover-image {
-                height: 66%;
+                height: 66vh;
             }
         }
         @media (max-aspect-ratio: 6/5) {
@@ -67,6 +69,8 @@
             padding: 0 !important;
             line-height: 1;
             text-transform: uppercase;
+            text-align: center;
+            /*font-size: 7vh;*/
         }
         .cover-text {
             grid-row: 1 / 1;
@@ -94,16 +98,33 @@
         h1 {
             margin: 0;
             padding: 0;
-            color: #fbfbfb;
-            text-align: center;
             
             /* -webkit-text-stroke-width: 3pt;
             -webkit-text-stroke-color: rgba(0, 0, 0, 1); */
-            text-shadow:
-                -2pt -2pt 1pt #000,  
-                2pt -2pt 1pt #000,
-                -2pt 2pt 1pt #000,
-                2pt 2pt 1pt #000;
+            --inverted-title-color: var(--swatch-background);
+            filter: 
+                drop-shadow(.01em .01em rgb(var(--inverted-title-color)))
+                drop-shadow(.01em -.01em rgb(var(--inverted-title-color)))
+                drop-shadow(-.01em .01em rgb(var(--inverted-title-color)))
+                drop-shadow(.01em .01em rgb(var(--inverted-title-color)));
+            /*text-shadow: 
+                -.2vh -.2vh .1vh rgb(var(--inverted-title-color)), 
+                .2vh -.2vh .1vh rgb(var(--inverted-title-color)),
+                -.2vh .2vh .1vh rgb(var(--inverted-title-color)), 
+                .2vh .2vh .1vh rgb(var(--inverted-title-color));*/
+        }
+        h2 {
+            margin: 0;
+            padding: 0;
+            
+            /* -webkit-text-stroke-width: 3pt;
+            -webkit-text-stroke-color: rgba(0, 0, 0, 1); */
+            --inverted-author-color: var(--swatch-text-dark);
+            filter: 
+                drop-shadow(.01em .01em rgb(var(--inverted-author-color)))
+                drop-shadow(.01em -.01em rgb(var(--inverted-author-color)))
+                drop-shadow(-.01em .01em rgb(var(--inverted-author-color)))
+                drop-shadow(.01em .01em rgb(var(--inverted-author-color)));
         }
         .cover {
             display: grid;
@@ -111,7 +132,8 @@
             grid-template-rows: 1fr;
         }
         .cover-image {
-            color: rgb(var(--swatch-text-light));
+            color: rgb(var(--swatch-text-general));            
+            opacity: .75;
         }
         .cover-image-container {
             grid-row: 1 / 1;
@@ -122,21 +144,16 @@
             align-items: center;
             height: 100vh;
         }
-        .colors {
-            color: #990000;
-            color: #ca6d6d;
-            color: #6e0f0f;
-        }
     </style>
 	</head>
 	<body>
 		<div class="cover">
             <div class="cover-text">
                 <div class="text-item">
-                    <h2 id="author" class="top-text fit">SCP Foundation</h2>
+                    <h1 id="page-title" class="bottom-text fit">Title Of Book</h1>
                 </div>
                 <div class="text-item">
-                    <h1 id="page-title" class="bottom-text fit">Title Of Book</h1>
+                    <h2 id="author" class="top-text fit">SCP Foundation</h2>
                 </div>
             </div>
             <div class="cover-image-container">
@@ -228,8 +245,12 @@
                 </svg>
             </div>
         </div>
+        <!-- Fitty called twice to avoid a glich where sometimes a different size is applied to the text -->
         <script>
-            fitty('.fit', {minSize: 60});
+            fitty('.fit');
+        </script>
+        <script>
+            fitty('.fit', { minSize: document.documentElement.clientHeight * 0.06 });
         </script>
 	</body>
 </html>


### PR DESCRIPTION
- Fix consistency of text sizes for different screen resolutions with same proportions
- Fix logo size
    - When a theme has it's own logo it didn't recognized the logo and had the wrong format
- Fix background size
- Gives logo a 0.5 opacity so that it doesn't interferes with long texts
- Add the theme 'extra-black-highlighter-theme' as default in the html template
- Add shadow on text for better reading in themes where the background color is the same as the text

fix #9 