### PR TITLE
Fix `figure` tags on modern Kobo e-readers.

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -173,7 +173,6 @@ sup {
 
 /* FIGURES + IMAGES  */
 figure {
-  display: table;
   page-break-inside: avoid;
   break-inside: avoid;
   margin: 1.2em auto;


### PR DESCRIPTION
This is a very small fix for modern Kobo devices which appear to break when trying to display figures with the `display: table;` style. More generally, it might be worth replacing the `base.css` file entirely with a more recent version from the Blitz repo. It is unmaintained and likely quite out of date, but certainly less out of date than the existing `base.css` present here, which is now nearly 6 years old.

Otherwise, thanks for this project. You have no idea how much I use this for binging articles while commuting :sweat_smile: 