### PR TITLE
WEBP image fix

### DIFF
--- a/src/lib/resource.js
+++ b/src/lib/resource.js
@@ -332,7 +332,7 @@ class Resource {
 		// const meta = await sharp(this.content).metadata();
 		// }
 
-		let shouldUsePng = /svg|gif|png|mng|apng/i.test(this.extension);
+		let shouldUsePng = /svg|gif|png|mng|apng|webp/i.test(this.extension);
 
         if ((this.content.length || this.content.size) >= jpegIfSizeLargerThan) {
             shouldUsePng = false;


### PR DESCRIPTION
Tried to grab SCP-9001 and almost every image failed to be downloaded and stored offline. I tried checking what the error was, and it seems to be related to the images being in a WEBP format. The SCP wiki sends WEBP images with a content type of `application/octet-stream`, which means that the `PostProcessor` fails the `resource.isImage` check here:

https://github.com/lselden/scp-to-epub/blob/624d17c69842beeb9616d103fbebb153a3c67e70/src/post-process.js#L87-L89

My hacky solution was to add a quick check to see if the filename ends with `.webp`. A better solution would be to check the contents of the file itself for webp magic bytes.