### PR TITLE
Fix image captions, blockquote compatibility, and empty appendix generation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -156,12 +156,56 @@ a[role~='doc-noteref'] {
 }
 
 figcaption {
-    border-bottom: 1pt solid currentColor;	
+    border-bottom: 1pt solid currentColor;
+    display: table-caption;
+    caption-side: bottom;
+    text-align: center;
+    font-size: 0.8em;
+    line-height: 1.2;
+    padding-top: 0.5em;
+}
+
+.scp-image-caption {
+    text-align: center;
+    word-break: normal;
+    overflow-wrap: break-word;
+    hyphens: auto;
+}
+
+.scp-image-caption p {
+    margin: 0;
+    padding: 0;
+    display: inline;
 }
 
 .scp-image-block {
+    display: table;
+    width: auto;
     max-width: 100%;
-    min-width: 50%;
+    min-width: 15em;
+    text-align: center;
+}
+
+.scp-image-block img {
+    display: block;
+    width: auto;
+    max-width: 100%;
+}
+
+.epub-figure-right {
+    float: right;
+    margin-left: 1em;
+}
+
+.epub-figure-left {
+    float: left;
+    margin-right: 1em;
+}
+
+.epub-figure-center {
+    display: table;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .cover-image img {
@@ -318,13 +362,13 @@ mark.blackbox {
     text-align: center;
 }
 
-blockquote {
-    border: 1px dotted rgba(127, 127, 127, 0.5);
+blockquote, .blockquote {
+    border: 1px solid #7f7f7f;
     border-radius: 0.125em;
-    padding: 0.125em;
-    margin-left: 0.125em;
-    margin-right: 0.125em;
+    padding: 0.5em 1em;
+    margin: 1em 0.125em;
     font-style: normal;
+    background-color: #f2f2f2;
 }
 
 /********************/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1850,7 +1850,8 @@
             "version": "0.0.1521046",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
             "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/dot-prop": {
             "version": "5.3.0",
@@ -2748,6 +2749,7 @@
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
             "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -3610,6 +3612,7 @@
             "integrity": "sha512-r8Ws43aYCnfO07ao0SvQRz4TBAtZJjGWNvScRBOHuiNHvjfECOJBIqJv0nUkL1GYcltjvvHswRilDF1ocsC0+g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@oxc-project/types": "=0.103.0",
                 "@rolldown/pluginutils": "1.0.0-beta.55"
@@ -4301,6 +4304,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "devOptional": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/src/lib/book.js
+++ b/src/lib/book.js
@@ -187,9 +187,12 @@ class Book {
 			'EPUB/package.opf': genManifest(this, this.options),
 			[`EPUB/${this.toc.path}`]: genToc(this, this.options),
 			[`EPUB/${this.toc.ncxPath}`]: genNcx(this, this.options),
-			[`EPUB/${this.toc.prefacePath}`]: genPreface(this, this.options),
-			[`EPUB/${this.toc.appendixPath}`]: genAppendix(this, this.options)
+			[`EPUB/${this.toc.prefacePath}`]: genPreface(this, this.options)
 		};
+
+		if (this.layout.appendix.length > 0) {
+			files[`EPUB/${this.toc.appendixPath}`] = genAppendix(this, this.options);
+		}
 
 		await pMap(Object.entries(files), ([filepath, content]) => {
 			return this.writeFile(path.join(destination, filepath), content);

--- a/src/templates/content.opf.js
+++ b/src/templates/content.opf.js
@@ -115,7 +115,11 @@ ${
 				.filter(x => x)
 				.join(EOL)
 		}
-		<item id="appendix" href="${ appendixPath }" media-type="application/xhtml+xml" />
+		${
+			(appendix.length > 0)
+				? `<item id="appendix" href="${ appendixPath }" media-type="application/xhtml+xml" />`
+				: ''
+		}
 	</manifest>
 
 	<spine toc="ncx">
@@ -136,7 +140,11 @@ ${
 				})
 				.join(EOL)
 		}
-		<itemref idref="appendix" />
+		${
+			(appendix.length > 0)
+				? '<itemref idref="appendix" />'
+				: ''
+		}
 	</spine>
 </package>`
 }

--- a/src/templates/toc.xhtml.js
+++ b/src/templates/toc.xhtml.js
@@ -114,14 +114,7 @@ function genToc(data, options = {}) {
 					})
 					.join('\n')
 
-		}<li class="toc-doc-part"><a href="${appendixPath}">Appendix</a>${
-			''
-			// <ol class="toc-list">${
-			// supplemental.map(chapter => {
-			// 	return formatChapter(chapter);
-			// }).join('\n')
-			//</ol>
-		}</li>
+		}${ (supplemental.length > 0) ? `<li class="toc-doc-part"><a href="${appendixPath}">Appendix</a></li>` : '' }
 		</ol>
 	</nav>
 	<nav epub:type="landmarks" id="guide" hidden="hidden">
@@ -130,7 +123,7 @@ function genToc(data, options = {}) {
 			<li><a epub:type="toc" href="#toc">${ tocTitle }</a></li>
 			<li><a epub:type="frontmatter" href="${prefacePath}">Preface</a></li>
 			<li><a epub:type="bodymatter" href="${ firstChapter.bookPath }">Begin Reading</a></li>
-			<li><a epub:type="backmatter" href="${appendixPath}">Appendix</a></li>
+			${ (supplemental.length > 0) ? `<li><a epub:type="backmatter" href="${appendixPath}">Appendix</a></li>` : '' }
 		</ol>
 	</nav>
 </div>`;

--- a/static/client/figures.js
+++ b/static/client/figures.js
@@ -52,13 +52,17 @@ export default function () {
 		newEl.classList.value = `epub-figure ${container.classList.value.replace(/block-(left|right|center)/, 'epub-figure-$1')}`;
 		// container.parentNode.insertBefore(newEl, block);
 
+        if (container.style.width) {
+            newEl.style.width = container.style.width;
+        }
+
 		image.removeAttribute('style');
 		image.removeAttribute('width');
 		image.removeAttribute('height');
 		newEl.appendChild(image);
 		newEl.insertAdjacentHTML(
 			'beforeend',
-			`<figcaption class="scp-image-caption">${caption.innerHTML}</figcaption>`
+			`<figcaption class="scp-image-caption">${caption.innerHTML.replace(/<\/?p[^>]*>/g, '')}</figcaption>`
 		);
 
 		container.replaceWith(newEl);


### PR DESCRIPTION
### Summary
This PR addresses several formatting and structural issues discovered during EPUB generation, specifically focusing on improving the visual layout of image captions, enhancing blockquotes, and cleaning up the book structure.

  ### Changes

  1. Image Captions & Blocks
   * Width Matching: Implemented display: table on .scp-image-block to force captions to wrap according to the image's
     width, preventing them from extending wider than the image.
   * Width Preservation: Updated the client-side conversion script to preserve explicit widths (e.g., width: 50%) from
     the original wiki containers.
   * Paragraph Stripping: Captions now have nested \<p> tags stripped during conversion to prevent "off" formatting and
     ensure consistent line height.
   * Stability: Added a min-width: 15em and improved word-wrapping/hyphenation to prevent excessive line breaks in long
     captions on narrow screens.

  2. Blockquote Improvements
   * Class Support: Added styling for the .blockquote class to support the div-based blockquotes commonly used on the
     SCP Wiki.

  3. Structural Fixes
   * Conditional Appendix: Modified the book-maker logic to only generate and include appendix.xhtml if there are
     actually supplemental chapters. This removes the "Empty Appendix" page found in single-page or low-depth
     conversions.
   * Manifest/TOC Cleanup: Updated the OPF manifest, spine, and Table of Contents templates to conditionally link the
     appendix based on content.

  ### Verification Results
   * SCP-9113: Verified that the image caption respects the width: 50% attribute and that the empty appendix is gone.
   * SCP-9114: Verified that the long caption "Recovered photograph from Mrs. Tuğba Sibel's Camera" wraps naturally
     without excessive breaks and that the nested blockquotes are styled correctly for Kindle.